### PR TITLE
Tiny bug fix from infinitePatch2

### DIFF
--- a/src/main/java/dev/eliux/monumentaitemdictionary/gui/builder/BuilderGui.java
+++ b/src/main/java/dev/eliux/monumentaitemdictionary/gui/builder/BuilderGui.java
@@ -216,7 +216,11 @@ public class BuilderGui extends Screen {
             DictionaryItem item  = buildItems.get(i);
             baseUrl.append(itemTypesIndex.get(i).substring(0, 1).toLowerCase()).append("=");
             if (item != null) {
-                if (!item.region.equals("Ring")) baseUrl.append(item.name.replace(" ", "%20")).append("&");
+                if (!item.region.equals("Ring")) {
+                    if (item.name.equals("Carcano 91/38"))
+                        baseUrl.append(item.name.replace(" ", "%20").replace("/", "")).append("&"); //CARCANO HARDCODE
+                    else baseUrl.append(item.name.replace(" ", "%20")).append("&");
+                }
                 else {
                     if (isItemExalted(item)) baseUrl.append("EX ");
                     baseUrl.append(item.name.replace(" ", "%20")).append(String.format("-%d", item.getMaxMasterwork()-1)).append("&");
@@ -300,7 +304,8 @@ public class BuilderGui extends Screen {
 
             String itemType = rawItem.substring(0, 1);
 
-            item = controller.getItemByName(itemName, isExalted);
+            if (itemName.equals("Carcano 9138")) item = controller.getItemByName("Carcano 91/38", isExalted); //CARCANO HARDCODE
+            else item = controller.getItemByName(itemName, isExalted);
             if (item == null) { continue; }
 
             switch (itemType) {

--- a/src/main/java/dev/eliux/monumentaitemdictionary/gui/charm/CharmDictionaryGui.java
+++ b/src/main/java/dev/eliux/monumentaitemdictionary/gui/charm/CharmDictionaryGui.java
@@ -335,7 +335,10 @@ public class CharmDictionaryGui extends Screen {
 
         lines.add(Text.literal("When in Charm Slot:").setStyle(Style.EMPTY.withColor(0xAAAAAA)));
         for (CharmStat stat : charm.stats) {
-            lines.add(Text.literal((stat.statLocked ? "\uD83D\uDD12 " : "") + (stat.statValue >= 0 ? "+" : "") + stat.statValue + (stat.statNameFull.endsWith("percent") ? "" : " ") + ItemFormatter.formatCharmStat(stat.statNameFull)).setStyle(Style.EMPTY
+            if (charm.name.equals("Psychosis") && stat.statNameFull.equals("amplifying_hex_max_debuffs_flat"))
+                lines.add(Text.literal((stat.statLocked ? "\uD83D\uDD12 " : "") + stat.statValue + " " + ItemFormatter.formatCharmStat(stat.statNameFull)).setStyle(Style.EMPTY
+                    .withColor(ItemColors.getColorForCharmStat(stat)))); //PSYCHOSIS HARDCODE
+            else lines.add(Text.literal((stat.statLocked ? "\uD83D\uDD12 " : "") + (stat.statValue >= 0 ? "+" : "") + stat.statValue + (stat.statNameFull.endsWith("percent") ? "" : " ") + ItemFormatter.formatCharmStat(stat.statNameFull)).setStyle(Style.EMPTY
                     .withColor(ItemColors.getColorForCharmStat(stat))));
         }
 

--- a/src/main/java/dev/eliux/monumentaitemdictionary/util/ItemColors.java
+++ b/src/main/java/dev/eliux/monumentaitemdictionary/util/ItemColors.java
@@ -227,8 +227,14 @@ public class ItemColors {
                 || charmStat.statNameFull.contains("delay")
                 || charmStat.statNameFull.contains("price")
                 || charmStat.statNameFull.contains("received_damage")
-                || charmStat.statNameFull.contains("threshold")
-                || (charmStat.statLocked && charmStat.statNameFull.contains("max_debuff")); // Hardcoded for Psychosis
+                /* Hardcode Affected Charm Note
+                    Silver Codex, Focused/Greater/Lesser Executioner's Charm: Coup de Grace health threshold
+                    Loci's Hunger: Rampage stacks needed for activation
+                    Rocket Boots: Meteor Slam reduced threshold
+                    Psychosis: Locked Amplifying Hex max debuffs */
+                || (charmStat.statNameFull.contains("threshold") && !(charmStat.statNameFull.contains("coup_de_grace") || charmStat.statNameFull.equals("meteor_slam_reduced_threshold_flat")))
+                || charmStat.statNameFull.equals("rampage_stacks_needed_for_activation_flat")
+                || (charmStat.statLocked && charmStat.statNameFull.equals("amplifying_hex_max_debuffs_flat"));
         return (positive ^ inverted) ? TEXT_POSITIVE_CHARM_COLOR : TEXT_NEGATIVE_CHARM_COLOR;
     }
 


### PR DESCRIPTION
### Fix some incorrect charm stat color
Affected Charm by this change
 - Silver Codex
 - Focused/Greater/Lesser Executioner's Charm
 - Loci's Hunger
 - Rocket Boots